### PR TITLE
Adding a page containing a link which redirects

### DIFF
--- a/server.rb
+++ b/server.rb
@@ -168,3 +168,11 @@ get '/status_codes/:status_code' do |status_code|
   @status_code = status_code
   erb :status_code
 end
+
+get '/redirect' do
+  redirect '/status_codes'
+end
+
+get '/redirector' do
+  erb :redirector
+end

--- a/views/redirector.erb
+++ b/views/redirector.erb
@@ -1,0 +1,6 @@
+<div class="example">
+  <h3>Redirection</h3>
+  <p>
+    This page contains <a id='redirect' href='redirect'>a link that redirects</a> to the status codes page.
+  </p>
+</div>


### PR DESCRIPTION
This adds a /redirector page, which contains a link that redirects to the status_codes page. This is separate from directly returning a redirection status code, in that some browsers cannot handle a raw redirect status code without a destination page as part of the HTTP response. Feel free to modify/adapt to better suit the needs of the project.
