### PR TITLE
Adding a page with a JavaScript error in the onload event

### DIFF
--- a/server.rb
+++ b/server.rb
@@ -168,3 +168,7 @@ get '/status_codes/:status_code' do |status_code|
   @status_code = status_code
   erb :status_code
 end
+
+get '/javascript_error' do
+  erb :javascript_error, :layout => false
+end

--- a/views/javascript_error.erb
+++ b/views/javascript_error.erb
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Page with JavaScript errors on load</title>
+    <script>
+      function loadError() {
+        var xx = document.propertyThatDoesNotExist.xyz;
+      }
+    </script>
+  <head>
+  <body onload="loadError()">
+    <p>
+      This page has a JavaScript error in the onload event.
+      This is often a problem to using normal Javascript injection
+      techniques.
+    </p>
+  </body>
+</html>


### PR DESCRIPTION
This is to be used to demonstrate the use of a proxy to inject error-handling code to a page to catch potential JavaScript errors in the page's onload event. Note that it does not use the standard rendered template, as that does not include an onload event handler. Feel free to modify/adapt/prettify as appropriate.
