### PR TITLE
Update frame_bottom.erb

### DIFF
--- a/views/float.erb
+++ b/views/float.erb
@@ -1,0 +1,2 @@
+<!-- Link within bottom frame iFrame contained in frames example. -->
+<a href="http://the-internet.herokuapp.com/frames" target="_blank">This link will open in new window/tab</a>

--- a/views/frame_bottom.erb
+++ b/views/frame_bottom.erb
@@ -2,8 +2,7 @@ BOTTOM
 <div class="example">
   <h3>Demonstration of an HTML4 IFRAME within a FRAME and FRAMESET.</h3>
   <center>
-  <iframe name="inlineframe" src="float.html" frameborder="0" scrolling="auto" width="500" height="180" marginwidth="5" marginheight="5" >
-      <a href="http://the-internet.herokuapp.com/frames" target="_blank">This link will open in new window/tab</a>
+  <iframe name="inlineframe" src="float" frameborder="0" scrolling="auto" width="500" height="180" marginwidth="5" marginheight="5" >      
   </iframe>
   </center>
 </div>


### PR DESCRIPTION
Updated frame_bottom.erb  to have an example of an iFrame  within the /frames URI.   Please modify to suite the usage.  I am only making a suggestion here that is testable by a Selenium script by having a hyperlink that opens a new window.

Keep in mind that if a Selenium script actually clicks the link to open the new window, the browser instance will end up having an array of 7 windows I think:   default, left, right, middle, bottom, iframe, and new_window.  Is this correct?
