### PR TITLE
Fix a misspelling in javascript_alerts.erb

### DIFF
--- a/views/javascript_alerts.erb
+++ b/views/javascript_alerts.erb
@@ -1,7 +1,7 @@
 <script>
   function jsAlert() {
     alert('I am a JS Alert');
-    log('You successfuly clicked an alert');
+    log('You successfully clicked an alert');
   }
 
   function jsConfirm() {


### PR DESCRIPTION
"successfully" was misspelled as "successfuly" in the result label "You successfuly clicked an alert" in the javascript_alerts view. I fixed it.