### PR TITLE
Dockerfile should use appropriate version of ruby image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-FROM ruby:2.4.1
+FROM ruby:2.7.2
 
 ADD Gemfile /app/
 ADD Gemfile.lock /app/
 WORKDIR /app
+RUN bundle update --bundler
 RUN bundle install
 ADD . /app
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,4 +121,4 @@ RUBY VERSION
    ruby 2.7.2
 
 BUNDLED WITH
-   1.17.3
+   2.1.4


### PR DESCRIPTION
And Gemfile.lock should request appropriate version of bundler.