### PR TITLE
Add Subdirectory navigation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Deployed and available at [http://the-internet.herokuapp.com](http://the-interne
 + [Slow Resources](http://the-internet.herokuapp.com/slow)
 + [Sortable Data Tables](http://the-internet.herokuapp.com/tables)
 + [Status Codes](http://the-internet.herokuapp.com/status_codes)
++ [Subdirectories](http://the-internet.herokuapp.com/subdirectories)
 + [Typos](http://the-internet.herokuapp.com/typos)
 + [WYSIWYG Editor](http://the-internet.herokuapp.com/tinymce)
 

--- a/examples.csv
+++ b/examples.csv
@@ -43,3 +43,4 @@ Add/Remove Elements,/add_remove_elements/
 Inputs,/inputs
 Digest Authentication,/digest_auth,user and pass: admin
 Shadow DOM,/shadowdom
+Subdirectories,/subdirectories

--- a/server.rb
+++ b/server.rb
@@ -448,26 +448,26 @@ class Public < Sinatra::Base
 
   get '/challenging_dom' do
     require 'uuid'
-    @text = %w(foo bar baz qux)
+    @text = %w[foo bar baz qux]
     @id = []
     20.times { @id << UUID.new.generate }
     erb :challenging_dom
   end
 
   get '/disappearing_elements' do
-    markup = [%q{<ul>
+    markup = [%q(<ul>
                     <li><a href="/">Home</a></li>
                     <li><a href="/about/">About</a></li>
                     <li><a href="/contact-us/">Contact Us</a></li>
                     <li><a href="/portfolio/">Portfolio</a></li>
                     <li><a href="/gallery/">Gallery</a></li>
-                  <ul>},
-                %q{<ul>
+                  <ul>),
+                %q(<ul>
                     <li><a href="/">Home</a></li>
                     <li><a href="/about/">About</a></li>
                     <li><a href="/contact-us/">Contact Us</a></li>
                     <li><a href="/portfolio/">Portfolio</a></li>
-                  <ul>}]
+                  <ul>)]
     @payload = markup[rand(2)]
     erb :disappear
   end
@@ -512,4 +512,16 @@ class Public < Sinatra::Base
   get '/inputs' do
     erb :inputs
   end
+
+  # subdirectories
+  get '/subdirectories' do
+    erb :'subdirectories/index'
+  end
+
+  %w[one two].each do |dir|
+    get "/subdirectories/#{dir}" do
+      erb :"/subdirectories/#{dir}/index"
+    end
+  end
+  # /subdirectories
 end

--- a/views/examples.erb
+++ b/views/examples.erb
@@ -40,6 +40,7 @@
   <li><a href='/shifting_content'>Shifting Content</a></li>
   <li><a href='/slow'>Slow Resources</a></li>
   <li><a href='/tables'>Sortable Data Tables</a></li>
+  <li><a href="/subdirectories">Subdirectories</a></li>
   <li><a href='/status_codes'>Status Codes</a></li>
   <li><a href='/typos'>Typos</a></li>
   <li><a href='/tinymce'>WYSIWYG Editor</a></li>

--- a/views/subdirectories/index.erb
+++ b/views/subdirectories/index.erb
@@ -1,0 +1,10 @@
+<div class="example">
+  <h1>Subdirectories</h1>
+
+  <p>You are here: <pre>/subdirectories</pre></p>
+
+  <ol>
+    <li><a href="/subdirectories/one"><pre>/subdirectories/one</pre></a></li>
+    <li><a href="/subdirectories/two"><pre>/subdirectories/two</pre></a></li>
+  </ol>
+</div>

--- a/views/subdirectories/one/index.erb
+++ b/views/subdirectories/one/index.erb
@@ -1,0 +1,10 @@
+<div class="example">
+  <h1>Subdirectory One</h1>
+
+  <p>You are here: <pre>/subdirectories/one</pre></p>
+
+  <ol>
+    <li><a href="/subdirectories"><pre>/subdirectories</pre></a></li>
+    <li><a href="/subdirectories/two"><pre>/subdirectories/two</pre></a></li>
+  </ol>
+</div>

--- a/views/subdirectories/two/index.erb
+++ b/views/subdirectories/two/index.erb
@@ -1,0 +1,10 @@
+<div class="example">
+  <h1>Subdirectory Two</h1>
+
+  <p>You are here: <pre>/subdirectories/two</pre></p>
+
+  <ol>
+    <li><a href="/subdirectories"><pre>/subdirectories</pre></a></li>
+    <li><a href="/subdirectories/one"><pre>/subdirectories/one</pre></a></li>
+  </ol>
+</div>


### PR DESCRIPTION
Often the path continues on past the root directory.  This adds a structure of:

```
/subdirectories
  /one
  /two
```

With an index page in each.  This is useful for testing navigations within common paths.

![Screen Shot 2021-09-14 at 19 30 48](https://user-images.githubusercontent.com/2972876/133347282-6bb41a90-f935-4478-9273-e16e20cdd2e2.png)
![Screen Shot 2021-09-14 at 19 30 52](https://user-images.githubusercontent.com/2972876/133347293-13a8b97f-2b62-4ac7-971d-0511b417e154.png)
